### PR TITLE
Correct version to 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def setup():
 
     setuptools.setup(
         name="pybashrc",
-        version="1.0.1",
+        version="1.1.0",
         author="Jelmer Neeven",
         author_email="author@example.com",
         description="Register python functions as bash commands",


### PR DESCRIPTION
Accidentally typed `1.0.1` instead of `1.1.0`...